### PR TITLE
Update calculator.py

### DIFF
--- a/calculator.py
+++ b/calculator.py
@@ -89,7 +89,7 @@ def resolve_path(path):
         'multiply' : multiply
     }
     path = path.strip('/').split('/')
-    func = path[0]
+    func_name = path[0]
     args = path[1:]
 
     try:


### PR DESCRIPTION
Using `func_name` in line 96, and not defining it in line 92 was causing an unexpected `NameError`, which was being picked up by the code in `application` and resulted in a 404. This is kind of an unfortunate issue, but show up in office hours if you'd like more help addressing it!